### PR TITLE
EC2対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ services:
     environment:
       - GF_PLUGINS_PREINSTALL=yesoreyeram-infinity-datasource@${GRAFANA_PLUGIN_INFINITY_VERSION}
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/FloodMonitoring.json
-      - GF_SECURITY_ALLOW_EMBEDDING=true
-      - GF_SECURITY_COOKIE_SAMESITE=none
-      - GF_SECURITY_COOKIE_SECURE=true
       - GF_PANELS_DISABLE_SANITIZE_HTML=true
       - GF_LOG_LEVEL=debug
     volumes:

--- a/testdata/index.js
+++ b/testdata/index.js
@@ -114,7 +114,7 @@ async function sendLevelToFiware(level) {
             type: FIWARE_ENTITY_TYPE,
             ...payload // payload に @context が含まれないようにする
         }];
-        console.log(JSON.stringify(createPayload, null, 2));
+        // console.log(JSON.stringify(createPayload, null, 2));
         const upsertUrl = `${FIWARE_ORION_URL}/entityOperations/upsert`;
         await axios.post(upsertUrl, createPayload, { headers });
         console.log(`[${new Date().toLocaleTimeString()}] Water level ${level.toFixed(2)}m (${currentState} state) sent to FIWARE.`);


### PR DESCRIPTION
# 概要
EC2でGrafanaダッシュボードが表示されるように対応する

# 修正内容

- grafana: 本来指定する必要がなかった環境変数を削除する
    - GF_SECURITY_ALLOW_EMBEDDING
    - GF_SECURITY_COOKIE_SAMESITE
    - GF_SECURITY_COOKIE_SECURE

- testdata: 不要なログ出力を削除する

# 影響範囲

- Grafanaのダッシュボード表示に影響する

# レビュー観点

- 対象の変数のみ削除していること

# 補足

- EC2で動作確認済み