### PR TITLE
自動起動対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       org.fiware: ${COMPOSE_LABEL_FIWARE}
     image: grafana/grafana-enterprise:${GRAFANA_VERSION}
     container_name: grafana
-    restart: unless-stopped
     networks:
       - default
     ports:

--- a/testdata/index.js
+++ b/testdata/index.js
@@ -2,6 +2,7 @@ const dotenv = require('dotenv');
 const dotenvExpand = require('dotenv-expand');
 dotenvExpand.expand(dotenv.config());
 const axios = require('axios');
+const commandLineArgs = require('command-line-args');
 
 // --- 設定値 ---
 const FIWARE_ORION_URL = process.env.FIWARE_ORION_URL; // /ngsi-ld/v1 エンドポイント
@@ -38,6 +39,20 @@ let lastStateTransitionTime = Date.now(); // 最後に状態が移行したタ�
 
 let transitionStepCounter = 0; // 移行中のステップカウンター
 let levelChangePerStep = 0; // 移行中のステップごとの水位変化量
+
+// --- 引数 ---
+const optionDefinitions = [
+  {
+    name: 'verbose',
+    alias: 'v',
+    type: Boolean
+  }
+];
+const options = commandLineArgs(optionDefinitions);
+
+// デバッグログ出力用(引数に-vを付けた時だけ出力する)
+const debugLog = (options.verbose)? console.log.bind(console) : ()=>{};
+
 
 // --- ヘルパー関数 ---
 
@@ -114,10 +129,10 @@ async function sendLevelToFiware(level) {
             type: FIWARE_ENTITY_TYPE,
             ...payload // payload に @context が含まれないようにする
         }];
-        // console.log(JSON.stringify(createPayload, null, 2));
+        // debugLog(JSON.stringify(createPayload, null, 2));
         const upsertUrl = `${FIWARE_ORION_URL}/entityOperations/upsert`;
         await axios.post(upsertUrl, createPayload, { headers });
-        console.log(`[${new Date().toLocaleTimeString()}] Water level ${level.toFixed(2)}m (${currentState} state) sent to FIWARE.`);
+        debugLog(`[${new Date().toLocaleTimeString()}] Water level ${level.toFixed(2)}m (${currentState} state) sent to FIWARE.`);
     } catch (error) {
         console.error(`[${new Date().toLocaleTimeString()}] Error sending data to FIWARE:`, error.response ? error.response.data : error.message);
     }

--- a/testdata/index.js
+++ b/testdata/index.js
@@ -42,16 +42,16 @@ let levelChangePerStep = 0; // 移行中のステップごとの水位変化量
 
 // --- 引数 ---
 const optionDefinitions = [
-  {
-    name: 'verbose',
-    alias: 'v',
-    type: Boolean
-  }
+    {
+        name: 'verbose',
+        alias: 'v',
+        type: Boolean
+    }
 ];
 const options = commandLineArgs(optionDefinitions);
 
 // デバッグログ出力用(引数に-vを付けた時だけ出力する)
-const debugLog = (options.verbose)? console.log.bind(console) : ()=>{};
+const debugLog = (options.verbose) ? console.log.bind(console) : () => { };
 
 
 // --- ヘルパー関数 ---

--- a/testdata/package-lock.json
+++ b/testdata/package-lock.json
@@ -10,8 +10,18 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.10.0",
+        "command-line-args": "^6.0.1",
         "dotenv": "^16.6.0",
         "dotenv-expand": "^12.0.2"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/asynckit": {
@@ -54,6 +64,29 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/delayed-stream": {
@@ -149,6 +182,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/follow-redirects": {
@@ -284,6 +334,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -319,6 +375,15 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     }
   }
 }

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -11,6 +11,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.10.0",
+    "command-line-args": "^6.0.1",
     "dotenv": "^16.6.0",
     "dotenv-expand": "^12.0.2"
   }


### PR DESCRIPTION
# 概要
EC2起動時に秋田版農業情報基盤とGrafana、テストデータ投入スクリプトを自動起動するために修正を行う。

# 修正内容


### Grafana
- コンテナ自体が自動起動しないようにdocker-compose.ymlからrestart属性を削除する。

### testdata
- -vオプションで起動した場合のみ定期的なログが出力されるように修正する。

# 影響範囲

- EC2起動時のコンテナ自動起動に影響する
- テストデータ投入スクリプトのログ出力に影響する

# レビュー観点

- 既存機能に影響がないこと

# 補足
