### PR TITLE
時刻範囲に従ったデータ取得

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ services スクリプトを実行することによって、アプリケーシ�
 
 # データの可視化
 [Grafana](https://grafana.com/ja/)を使って情報基盤のデータを確認できます。Webブラウザで[http://localhost:3000](http://localhost:3000)にアクセスしてください。  
-(ユーザ名：admin、初期パスワード：admin)
+(ユーザ名：admin、パスワード：ak-agri)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     ports:
       - "${GRAFANA_PORT}:${GRAFANA_PORT}"
     environment:
+      - GF_SECURITY_ADMIN_PASSWORD=ak-agri
       - GF_PLUGINS_PREINSTALL=yesoreyeram-infinity-datasource@${GRAFANA_PLUGIN_INFINITY_VERSION},marcusolsson-static-datasource@${GRAFANA_PLUGIN_BUSINESS_INPUT},dalvany-image-panel@${GRAFANA_PLUGIN_DYNAMIC_IMAGE_PANEL}
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/FloodMonitoring.json
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=nmcclain-iframe-panel

--- a/grafana/dashboards/FloodMonitoring.json
+++ b/grafana/dashboards/FloodMonitoring.json
@@ -176,6 +176,14 @@
               {
                 "key": "attrs",
                 "value": "currentLevel,observationDateTime"
+              },
+              {
+                "key": "fromDate",
+                "value": "${__from:date:iso}"
+              },
+              {
+                "key": "toDate",
+                "value": "${__to:date:iso}"
               }
             ]
           }

--- a/testdata/index.js
+++ b/testdata/index.js
@@ -181,7 +181,10 @@ function sendSubscriptionToFiware() {
             format: 'normalized',
             endpoint: {
                 uri: `${FIWARE_QUANTUM_LEAP_URL}/notify`,
-                accept: 'application/json'
+                accept: 'application/json',
+                receiverInfo: [
+                    { 'key': 'Fiware-TimeIndex-Attribute', 'value': 'observationDateTime' }
+                ]
             }
         },
         '@context': `${FIWARE_CONTEXT}`


### PR DESCRIPTION
## 概要

Grafanaのダッシュボードの時刻範囲に従ってデータを取得する

## 対応内容

- Quantumleapから永続データを取得するときに時刻を指定する
- CrateDBに記録されるタイムインデックスをFloodMonitoringのobservationDateTimeの時刻に変更する
- adminのパスワードを変更する

## 影響範囲

- 水位グラフの表示
- Grafanaの管理者ログイン

## 動作確認

- Grafanaのダッシュボードの時刻範囲を5分にしたとき、直近5分間のデータしか取得されないこと
- Grafanaにadminでログインするとき、変更したパスワードでログインできること
- Grafanaにadminでログインしたとき、パスワードの変更が求められないこと

## 制約事項

特になし

## レビュー観点

特になし

## レビュー期間

2025/07/31(木) - 2025/08/04(月)

## 補足

特になし
