### PR TITLE
SP6 リバースプロキシのポート番号変更に対応

### DIFF
--- a/testdata/.env
+++ b/testdata/.env
@@ -5,7 +5,7 @@ STATION_LAT=39.341048
 STATION_LON=140.078978
 
 # FIWAREコンポーネント
-FIWARE_ORION_URL=http://localhost:8080/api/orion/ngsi-ld/v1
+FIWARE_ORION_URL=http://localhost/api/orion/ngsi-ld/v1
 FIWARE_QUANTUM_LEAP_URL=http://quantumleap:8668/v2
 # FIWAREエンティティID
 FIWARE_ENTITY_TYPE=FloodMonitoring


### PR DESCRIPTION
## 概要

SP6でPlatformのリバースプロキシのポート番号の変更になったため、対応を行う

## 対応内容

- Orionのサービスを呼び出すURLのポート番号を8080番から80番に変更する

## 影響範囲

- Orionへの水位データ投入処理に影響する

## 動作確認

- 開発環境、本番環境において、水位データ投入スクリプトが正しく水位データをOrionに登録できること

## 制約事項

- SP6に対応したPlatformでのみ正しく動作する

## レビュー観点

特になし

## レビュー期間

2025年10月22日(水) ～ 10月24日(金)

## 補足

特になし
